### PR TITLE
Add Ontology Term Validation package (ontology-terms) - 2026 symposium output

### DIFF
--- a/2026/Ontology-Term-Validation/README.md
+++ b/2026/Ontology-Term-Validation/README.md
@@ -2,7 +2,7 @@
 authors:
   - name: Mohamed Abouzid
     orcid: https://orcid.org/0009-0007-7035-4399
-    affiliation: Forschungszentrum Jülich (IBG-4: Bioinformatics)
+    affiliation: Forschungszentrum Juelich
 ---
 
 # Ontology Term Validation for ARCs (`ontology-terms`)

--- a/2026/Ontology-Term-Validation/README.md
+++ b/2026/Ontology-Term-Validation/README.md
@@ -1,7 +1,7 @@
 ---
 authors:
   - name: Mohamed Abouzid
-    orcid: 0009-0007-7035-4399
+    orcid: https://orcid.org/0009-0007-7035-4399
     affiliation: Forschungszentrum Jülich (IBG-4: Bioinformatics)
 ---
 

--- a/2026/Ontology-Term-Validation/README.md
+++ b/2026/Ontology-Term-Validation/README.md
@@ -1,7 +1,7 @@
 ---
 authors:
   - name: Mohamed Abouzid
-    orcid: 0009-0007-7035-4399 
+    orcid: 0009-0007-7035-4399
     affiliation: Forschungszentrum Jülich (IBG-4: Bioinformatics)
 ---
 

--- a/2026/Ontology-Term-Validation/README.md
+++ b/2026/Ontology-Term-Validation/README.md
@@ -54,8 +54,8 @@ annotation in an ARC into a uniform record and runs **seven checks** across two 
 |---|-------|------|----------|------------------|
 | 1 | `pairing` | offline | error | Term Source REF and Term Accession Number are either both present or both absent |
 | 2 | `wellformed` | offline | error | the accession is a valid `PREFIX:LOCAL` id or IRI |
-| 3 | `source_declared` | offline | error | the Term Source REF is declared in the Investigation ONTOLOGY SOURCE REFERENCE section |
-| 4 | `prefix_consistency` | offline | error | the accession prefix matches its Term Source REF |
+| 3 | `source_declared` | offline | warning | the Term Source REF is declared in the Investigation ONTOLOGY SOURCE REFERENCE section |
+| 4 | `prefix_consistency` | offline | warning | the accession prefix matches its Term Source REF |
 | 5 | `coverage` | offline | warning | flags free-text values that carry no ontology annotation |
 | 6 | `resolves` | online | error | the accession actually exists in a terminology service |
 | 7 | `label_match` | online | warning | the service's canonical label matches the annotation name |
@@ -89,6 +89,19 @@ The package emits the registry's standard three-file result contract into
   obo_id query silently fails for IRIs. → Accessions are **normalized** (OBO-style IRI →
   prefixed obo_id) before querying.
 
+- **The ONTOLOGY SOURCE REFERENCE section is not a settled convention, and prefixes can
+  legitimately cross namespaces** (raised in review by @HLWeil and @Freymaurer). Two
+  consequences shaped the final severity mapping:
+  - Use of the Investigation *ONTOLOGY SOURCE REFERENCE* section has been
+    [debated repeatedly](https://github.com/nfdi4plants/ARCtrl/issues/533) and never
+    settled; it is functionally an ISA artifact that many valid ARCs leave empty. Gating
+    on it would penalise legitimate ARCs. → **`source_declared` is a warning, not an
+    error.**
+  - An ontology may host terms whose id prefix differs from its source name — e.g. the
+    PSI-MS CV (`MS`) also hosts `PEFF:` ids, so `Term Source REF = MS` with
+    `Term Accession Number = PEFF:0000002` is a real, valid term. → **`prefix_consistency`
+    is a warning, not an error**, still surfacing likely typos without gating.
+
 ## Technical Details on Implementation
 
 - **Language / packaging:** one self-contained Python file
@@ -116,14 +129,20 @@ The package emits the registry's standard three-file result contract into
 ### Validated against a real ARC
 
 Run against the *Geobacillus thermoleovorans* ARC, the package surfaced concrete,
-correctly-located findings: ~287 `source_declared` errors (the ARC declares no ontology
+correctly-located findings: ~287 `source_declared` findings (the ARC declares no ontology
 sources at all), 119 free-text `coverage` warnings, and a handful of genuinely
 unresolvable accessions - the non-canonical `EFO:EFO_0005061` and
 `MICRO_MICRO_000052`, and `MIAPPE:0079` (MIAPPE is not hosted by TIB or OLS).
 Developing the online tier on this ARC also caught a real false-negative class:
 NCBITaxon accessions stored as IRIs were initially queried against the wrong field,
 producing ~250 spurious "does not resolve" errors; the IRI-normalization + OLS-fallback
-fix reduced the total error count from **542 to 294**, leaving only true findings.
+fix removed those, leaving only true findings.
+
+Note: following review, `source_declared` and `prefix_consistency` are now **warnings**
+(non-critical), so on this ARC the ~287 missing-declaration findings no longer count as
+critical errors - the only remaining critical (`error`-severity) findings are the genuine
+unresolvable accessions above. This keeps the package from gating ARCs on an unsettled
+convention while still reporting the signal.
 
 ## Automation / Enforcement
 

--- a/2026/Ontology-Term-Validation/README.md
+++ b/2026/Ontology-Term-Validation/README.md
@@ -1,0 +1,153 @@
+---
+authors:
+  - name: Mohamed Abouzid
+    orcid: 0009-0007-7035-4399 
+    affiliation: Forschungszentrum Jülich (IBG-4: Bioinformatics)
+---
+
+# Ontology Term Validation for ARCs (`ontology-terms`)
+
+A Python ARC validation package that checks whether the ontology / controlled-vocabulary
+(CV) annotations inside an ARC's ISA metadata are **complete, well-formed, declared, and
+resolvable against a terminology service**. Built as an output of the 2026 Hands-On
+Symposium and intended for contribution to the
+[arc-validate-package-registry](https://github.com/nfdi4plants/arc-validate-package-registry).
+
+## Motivation / Problem
+
+ARCs encourage rich, ontology-backed annotation: every `Characteristic`, `Parameter`,
+and `Factor` building block in a study or assay table can carry a *Term Source REF* and a
+*Term Accession Number* that anchor a free-text value to a controlled vocabulary
+(e.g. `Parameter [Temperature]` → `NCIT:C25206`). This is what makes ARC metadata
+interoperable and FAIR.
+
+However, the existing validation packages in the registry (invenio, pride, edal, odrl,
+plant-growth, hhu-cmml, ceplas) target **publication readiness** or **terms-of-use**,
+none of them check the *quality of the annotations themselves*. In practice this means a
+range of real problems go completely unvalidated:
+
+- a value annotated with an accession but no source (or vice versa);
+- a malformed accession;
+- a Term Source REF that is **never declared** in the Investigation's ONTOLOGY SOURCE
+  REFERENCE section;
+- an accession whose prefix disagrees with its declared source;
+- an accession that simply **does not exist** in any terminology service (a typo, a dead
+  term, or a non-canonical id).
+
+Inspecting real ARCs from the DataHUB confirmed this is not hypothetical. The
+*Geobacillus thermoleovorans* genomics ARC, for example, declares **zero** ontology
+sources despite citing OBI, NCIT, EFO, DPBO, MIAPPE and NCBITaxon throughout its tables,
+and stores several accessions in non-canonical, doubled-prefix form
+(`EFO:EFO_0005061`, `…/obo/MICRO_MICRO_000052`).
+
+A second, deliberate motivation: all seven existing packages are written in **F#**
+(on the ARCExpect DSL). The registry supports Python (executed via `uv`), but no
+non-trivial Python package existed. This package doubles as a demonstration that a
+real-world validation package can be authored in Python end-to-end.
+
+## Proposed Solution
+
+A single self-contained Python package, `ontology-terms`, that flattens every ontology
+annotation in an ARC into a uniform record and runs **seven checks** across two tiers:
+
+| # | Check | Tier | Severity | What it verifies |
+|---|-------|------|----------|------------------|
+| 1 | `pairing` | offline | error | Term Source REF and Term Accession Number are either both present or both absent |
+| 2 | `wellformed` | offline | error | the accession is a valid `PREFIX:LOCAL` id or IRI |
+| 3 | `source_declared` | offline | error | the Term Source REF is declared in the Investigation ONTOLOGY SOURCE REFERENCE section |
+| 4 | `prefix_consistency` | offline | error | the accession prefix matches its Term Source REF |
+| 5 | `coverage` | offline | warning | flags free-text values that carry no ontology annotation |
+| 6 | `resolves` | online | error | the accession actually exists in a terminology service |
+| 7 | `label_match` | online | warning | the service's canonical label matches the annotation name |
+
+The package emits the registry's standard three-file result contract into
+`.arc-validate-results/ontology-terms@<version>/`: a JUnit `validation_report.xml`
+(one case per check × term, located down to file/table/column/row), a
+`validation_summary.json`, and a status `badge.svg`.
+
+### Constraints discussed, and how they shaped the design
+
+- **Validation runs in isolated CQC environments where network is not guaranteed.**
+  Resolving an accession fundamentally requires a network call, which is at odds with
+  reproducible, offline CI. → The checks are **tiered**: the five offline checks always
+  run and are fully deterministic; the two online checks are attempted only when a
+  terminology service is reachable and otherwise reported as `skipped` (never `failed`),
+  so a network blip can never masquerade as an ARC defect. An
+  `ONTOLOGY_TERMS_OFFLINE=1` switch forces deterministic, network-free runs.
+
+- **ISA legitimately permits free-text values.** Flagging every unannotated value as an
+  error would be wrong and noisy. → `coverage` is a **warning**, a nudge toward FAIR
+  annotation rather than a gate.
+
+- **No single terminology service hosts every ontology.** During testing, DataPLANT's
+  canonical TIB Terminology Service returned the OBI/NCIT/EFO/DPBO terms but does **not**
+  host NCBITaxon, which EBI OLS does. → `resolves` queries **TIB first, then falls back
+  to OLS** before declaring a term unresolvable.
+
+- **Accessions appear in both prefixed and IRI form.** Real ARCs store accessions as
+  `NCIT:C25206` *and* as `http://purl.obolibrary.org/obo/NCBITAXON_33941`. A naive
+  obo_id query silently fails for IRIs. → Accessions are **normalized** (OBO-style IRI →
+  prefixed obo_id) before querying.
+
+## Technical Details on Implementation
+
+- **Language / packaging:** one self-contained Python file
+  (`ontology-terms@1.0.0.py`) with YAML frontmatter metadata and a `uv` inline
+  dependency block (`arctrl`, `requests`); executed by the registry/CQC pipeline via
+  `uv run`.
+- **ARC reading:** uses [**ARCtrl**](https://github.com/nfdi4plants/ARCtrl) (the polyglot
+  ARC library, `pip install arctrl`). `ARC.load()` reads the ARC; the package then walks
+  every study and assay table, extracting ontology annotations from both **column
+  headers** (`header.TryGetTerm()`) and **term / unitized cells**, plus the declared
+  ONTOLOGY SOURCE REFERENCE list. Reading through ARCtrl keeps the package aligned with
+  the rest of the toolstack rather than re-parsing XLSX by hand.
+- **Term resolution:** the TIB and OLS search APIs share a Solr-style response
+  (`/api/search?q=<obo_id>&queryFields=obo_id&exact=true`). Unique `(source, accession)`
+  pairs are de-duplicated and cached, queried with a short timeout and one retry, and
+  fall back TIB → OLS. A service that answers "not found" yields a genuine `error`; a
+  service that cannot be reached yields `skipped`.
+- **Output / severity mapping:** `error`-severity failures are critical (badge red and
+  `critical: true` in the summary); `warning`-severity failures are non-critical (badge
+  yellow); `skipped` never affects the verdict.
+- **Tests:** the checks are pure functions over a small data model, unit-tested without
+  any ARC on disk; the ARCtrl wiring and the full three-file output are tested
+  end-to-end against a real ARC fixture.
+
+### Validated against a real ARC
+
+Run against the *Geobacillus thermoleovorans* ARC, the package surfaced concrete,
+correctly-located findings: ~287 `source_declared` errors (the ARC declares no ontology
+sources at all), 119 free-text `coverage` warnings, and a handful of genuinely
+unresolvable accessions - the non-canonical `EFO:EFO_0005061` and
+`MICRO_MICRO_000052`, and `MIAPPE:0079` (MIAPPE is not hosted by TIB or OLS).
+Developing the online tier on this ARC also caught a real false-negative class:
+NCBITaxon accessions stored as IRIs were initially queried against the wrong field,
+producing ~250 spurious "does not resolve" errors; the IRI-normalization + OLS-fallback
+fix reduced the total error count from **542 to 294**, leaving only true findings.
+
+## Automation / Enforcement
+
+The package plugs directly into the existing DataPLANT automation chain, requiring no new
+infrastructure:
+
+1. **Distribution** - contribute the single `.py` file to `StagingArea/ontology-terms/`
+   in the [arc-validate-package-registry](https://github.com/nfdi4plants/arc-validate-package-registry);
+   the registry CI tests it and publishes it to [avpr.nfdi4plants.org](https://avpr.nfdi4plants.org).
+2. **Execution** - `arc-validate package install ontology-terms` then
+   `arc-validate validate -p ontology-terms` (the maintained, `uv`-equipped
+   `arc-validate` container build).
+3. **Continuous Quality Control** - once published, the package can be referenced in an
+   ARC's `.arc/validation_packages.yml` and is pulled and executed automatically by the
+   **DataHUB CQC pipelines** on every push, turning ontology-annotation quality into a
+   continuously-enforced, badge-reported property of the ARC.
+
+## Status & Next Steps
+
+- v1.0.0 implemented and tested; will be submitted with `Publish: false` for DataPLANT review.
+- Open items: confirm the summary/critical convention against the registry CI; consider
+  an optional ontology-source-allowlist; evaluate whether non-canonical "doubled-prefix"
+  accessions should be auto-normalized or kept as explicit findings.
+
+## Payload
+
+- `ontology-terms@1.0.0.py` - the validation package (add alongside this README).

--- a/2026/Ontology-Term-Validation/ontology-terms@1.0.0.py
+++ b/2026/Ontology-Term-Validation/ontology-terms@1.0.0.py
@@ -1,0 +1,376 @@
+PACKAGE_METADATA = """
+---
+Name: ontology-terms
+MajorVersion: 1
+MinorVersion: 0
+PatchVersion: 0
+Publish: false
+Summary: Validates that ontology/CV annotations in ARC ISA tables are complete, well-formed, declared, and resolvable.
+Description: |
+  Checks ontology term annotations on Characteristic/Parameter/Factor/Component building
+  blocks across all study and assay tables. Offline: source/accession pairing,
+  well-formedness, source declaration, prefix consistency, free-text coverage. Online
+  (when the TIB Terminology Service is reachable): accession resolution and label match.
+Author:
+  - FullName: Mohamed Abouzid
+    Email: m.abouzid@fz-juelich.de
+    Affiliation: Forschungszentrum Juelich
+Tags:
+  - Name: ontology
+  - Name: controlled vocabulary
+  - Name: FAIR
+  - Name: annotation
+  - Name: quality control
+---
+"""
+
+# /// script
+# dependencies = [
+#   "arctrl",
+#   "requests",
+# ]
+# ///
+
+NAME = "ontology-terms"
+VERSION = "1.0.0"
+TIB_API = "https://api.terminology.tib.eu/api/search"
+OLS_API = "https://www.ebi.ac.uk/ols4/api/search"
+
+
+import json
+import os
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from xml.dom import minidom
+
+_PREFIXED_RE = re.compile(r"^[A-Za-z][A-Za-z0-9.\-_]*:[A-Za-z0-9._\-]+$")
+_IRI_RE = re.compile(r"^https?://\S+$")
+
+
+@dataclass(frozen=True)
+class TermOccurrence:
+    name: str
+    source: str       # Term Source REF, "" if absent
+    accession: str    # Term Accession Number, "" if absent
+    location: str     # human-readable: "<container>/<table>/<where>"
+
+
+@dataclass
+class Finding:
+    check_id: str
+    severity: str     # "error" | "warning"
+    status: str       # "passed" | "failed" | "skipped"
+    message: str
+    location: str
+
+
+def load_arc(arc_dir):
+    from arctrl import ARC
+    return ARC.load(arc_dir)
+
+
+def declared_sources(arc):
+    out = set()
+    for ref in arc.OntologySourceReferences:
+        name = getattr(ref, "Name", None)
+        if name:
+            out.add(str(name).strip())
+    return out
+
+
+def _to_occurrence(oa, location):
+    return TermOccurrence(
+        name=(oa.Name or "").strip(),
+        source=(oa.TermSourceREF or "").strip(),
+        accession=(oa.TermAccessionNumber or "").strip(),
+        location=location,
+    )
+
+
+def collect_terms(arc):
+    occs = []
+    containers = list(arc.Studies) + list(arc.Assays)
+    for container in containers:
+        cid = getattr(container, "Identifier", "?")
+        for table in container.Tables:
+            tname = table.Name
+            for col in table.Columns:
+                header = col.Header
+                hterm = None
+                try:
+                    hterm = header.TryGetTerm()
+                except Exception:
+                    hterm = None
+                if hterm is not None and not hterm.is_empty():
+                    occs.append(_to_occurrence(hterm, f"{cid}/{tname}/header[{header}]"))
+                for i, cell in enumerate(col.Cells):
+                    oa = None
+                    try:
+                        if cell.is_term:
+                            oa = cell.AsTerm
+                        elif cell.is_unitized:
+                            _, oa = cell.AsUnitized
+                    except Exception:
+                        oa = None
+                    if oa is not None and not oa.is_empty():
+                        occs.append(_to_occurrence(oa, f"{cid}/{tname}/{header}/row{i + 1}"))
+    return occs
+
+
+def _is_iri(accession):
+    return bool(_IRI_RE.match(accession))
+
+
+def _pass(check_id, severity, occ):
+    return Finding(check_id=check_id, severity=severity, status="passed",
+                   message="ok", location=occ.location)
+
+
+def check_pairing(occ):
+    has_s, has_a = bool(occ.source), bool(occ.accession)
+    if has_s == has_a:
+        return _pass("pairing", "error", occ)
+    missing = "Term Accession Number" if has_s else "Term Source REF"
+    return Finding("pairing", "error", "failed",
+                   f"'{occ.name}' has only one of source/accession; missing {missing}.",
+                   occ.location)
+
+
+def check_wellformed(occ):
+    if not occ.accession:
+        return Finding("wellformed", "error", "skipped", "no accession", occ.location)
+    if _PREFIXED_RE.match(occ.accession) or _IRI_RE.match(occ.accession):
+        return _pass("wellformed", "error", occ)
+    return Finding("wellformed", "error", "failed",
+                   f"Accession '{occ.accession}' is not a valid PREFIX:LOCAL id or IRI.",
+                   occ.location)
+
+
+def check_source_declared(occ, declared):
+    if not occ.source:
+        return Finding("source_declared", "error", "skipped", "no source", occ.location)
+    declared_lower = {d.lower() for d in declared}
+    if occ.source.lower() in declared_lower:
+        return _pass("source_declared", "error", occ)
+    return Finding("source_declared", "error", "failed",
+                   f"Term Source REF '{occ.source}' is not declared in the "
+                   f"investigation ONTOLOGY SOURCE REFERENCE section.",
+                   occ.location)
+
+
+def check_prefix_consistency(occ):
+    if not (occ.source and occ.accession):
+        return Finding("prefix_consistency", "error", "skipped", "needs both", occ.location)
+    if _is_iri(occ.accession):
+        return Finding("prefix_consistency", "error", "skipped", "iri accession", occ.location)
+    prefix = occ.accession.split(":", 1)[0]
+    if prefix.lower() == occ.source.lower():
+        return _pass("prefix_consistency", "error", occ)
+    return Finding("prefix_consistency", "error", "failed",
+                   f"Accession prefix '{prefix}' does not match Term Source REF '{occ.source}'.",
+                   occ.location)
+
+
+def check_coverage(occ):
+    if occ.name and not occ.source and not occ.accession:
+        return Finding("coverage", "warning", "failed",
+                       f"'{occ.name}' is free text with no ontology annotation.",
+                       occ.location)
+    return _pass("coverage", "warning", occ)
+
+
+def run_offline(occurrences, declared):
+    findings = []
+    for occ in occurrences:
+        findings.append(check_pairing(occ))
+        findings.append(check_wellformed(occ))
+        findings.append(check_source_declared(occ, declared))
+        findings.append(check_prefix_consistency(occ))
+        findings.append(check_coverage(occ))
+    return findings
+
+
+def _query_id(accession):
+    """Convert an OBO-style IRI to a prefixed obo_id; pass prefixed ids through unchanged."""
+    if accession.startswith("http"):
+        segment = accession.rstrip("/").rsplit("/", 1)[-1]
+        if "_" in segment:
+            prefix, local = segment.rsplit("_", 1)
+            return f"{prefix}:{local}"
+        return segment
+    return accession
+
+
+def _try_search(api, query_id, session):
+    """Return (doc_or_None, responded) where responded is False only on transient error."""
+    for _attempt in range(2):
+        try:
+            r = session.get(api,
+                            params={"q": query_id, "queryFields": "obo_id",
+                                    "exact": "true", "rows": 1},
+                            timeout=5)
+            r.raise_for_status()
+            docs = r.json().get("response", {}).get("docs", [])
+            return (docs[0] if docs else None), True
+        except Exception:
+            continue
+    return None, False
+
+
+def resolve(accession, session, cache):
+    if accession in cache:
+        return cache[accession]
+    query_id = _query_id(accession)
+    found_doc = None
+    any_response = False
+    for api in (TIB_API, OLS_API):
+        doc, responded = _try_search(api, query_id, session)
+        any_response = any_response or responded
+        if doc is not None:
+            found_doc = doc
+            break
+    if found_doc is not None:
+        result = {"found": True, "label": found_doc.get("label")}
+    elif any_response:
+        result = {"found": False, "label": None}   # a service answered; term genuinely absent
+    else:
+        result = None                              # every service errored -> skip
+    cache[accession] = result
+    return result
+
+
+def check_resolves(occ, resolved):
+    if resolved is None:
+        return Finding("resolves", "error", "skipped",
+                       "terminology service unreachable", occ.location)
+    if resolved["found"]:
+        return _pass("resolves", "error", occ)
+    return Finding("resolves", "error", "failed",
+                   f"Accession '{occ.accession}' does not resolve in the terminology service.",
+                   occ.location)
+
+
+def check_label(occ, resolved):
+    if resolved is None or not resolved.get("found"):
+        return Finding("label_match", "warning", "skipped",
+                       "not resolved", occ.location)
+    canonical = (resolved.get("label") or "").strip().casefold()
+    given = (occ.name or "").strip().casefold()
+    if not canonical or canonical == given:
+        return _pass("label_match", "warning", occ)
+    return Finding("label_match", "warning", "failed",
+                   f"Annotation name '{occ.name}' differs from canonical label "
+                   f"'{resolved.get('label')}' for {occ.accession}.",
+                   occ.location)
+
+
+def run_online(occurrences, session):
+    findings = []
+    cache = {}
+    for occ in occurrences:
+        if not occ.accession:
+            continue
+        resolved = resolve(occ.accession, session, cache)
+        findings.append(check_resolves(occ, resolved))
+        findings.append(check_label(occ, resolved))
+    return findings
+
+
+def _counts(findings):
+    passed = sum(1 for f in findings if f.status == "passed")
+    skipped = sum(1 for f in findings if f.status == "skipped")
+    failed_errors = sum(1 for f in findings if f.status == "failed" and f.severity == "error")
+    warnings = sum(1 for f in findings if f.status == "failed" and f.severity == "warning")
+    return passed, failed_errors, warnings, skipped
+
+
+def write_junit(findings, path):
+    suites = ET.Element("testsuites", name=NAME)
+    for severity, suite_name in (("error", "errors"), ("warning", "warnings")):
+        group = [f for f in findings if f.severity == severity]
+        suite = ET.SubElement(suites, "testsuite", name=suite_name,
+                              tests=str(len(group)),
+                              failures=str(sum(1 for f in group if f.status == "failed")),
+                              skipped=str(sum(1 for f in group if f.status == "skipped")))
+        for f in group:
+            case = ET.SubElement(suite, "testcase", classname=f.check_id, name=f.location)
+            if f.status == "failed":
+                fail = ET.SubElement(case, "failure", type=f.severity, message=f.message)
+                fail.text = f.message
+            elif f.status == "skipped":
+                sk = ET.SubElement(case, "skipped", message=f.message)
+                sk.text = f.message
+    xml = minidom.parseString(ET.tostring(suites)).toprettyxml(indent="  ")
+    Path(path).write_text(xml, encoding="utf-8")
+
+
+def write_summary(findings, path):
+    passed, failed_errors, warnings, skipped = _counts(findings)
+    data = {
+        "package": NAME,
+        "version": VERSION,
+        "total": len(findings),
+        "passed": passed,
+        "failed_errors": failed_errors,
+        "warnings": warnings,
+        "skipped": skipped,
+        "critical": failed_errors > 0,
+    }
+    Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def write_badge(findings, path):
+    _, failed_errors, warnings, _ = _counts(findings)
+    if failed_errors:
+        color, status = "#e05d44", f"{failed_errors} errors"
+    elif warnings:
+        color, status = "#dfb317", f"{warnings} warnings"
+    else:
+        color, status = "#4c1", "passed"
+    label = "ontology-terms"
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" width="220" height="20" role="img" aria-label="{label}: {status}">
+  <rect width="130" height="20" fill="#555"/>
+  <rect x="130" width="90" height="20" fill="{color}"/>
+  <g fill="#fff" font-family="Verdana,Geneva,sans-serif" font-size="11">
+    <text x="8" y="14">{label}</text>
+    <text x="138" y="14">{status}</text>
+  </g>
+</svg>'''
+    Path(path).write_text(svg, encoding="utf-8")
+
+
+def _offline_forced():
+    return os.environ.get("ONTOLOGY_TERMS_OFFLINE", "").strip() in ("1", "true", "True")
+
+
+def main(argv=None):
+    arc_dir = os.environ.get("ARC_PATH") or os.getcwd()
+    out_dir = Path(arc_dir) / ".arc-validate-results" / f"{NAME}@{VERSION}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    arc = load_arc(arc_dir)
+    declared = declared_sources(arc)
+    occurrences = collect_terms(arc)
+
+    findings = run_offline(occurrences, declared)
+    if _offline_forced():
+        for occ in occurrences:
+            if occ.accession:
+                findings.append(Finding("resolves", "error", "skipped", "offline mode", occ.location))
+                findings.append(Finding("label_match", "warning", "skipped", "offline mode", occ.location))
+    else:
+        import requests
+        session = requests.Session()
+        findings += run_online(occurrences, session)
+
+    write_junit(findings, out_dir / "validation_report.xml")
+    write_summary(findings, out_dir / "validation_summary.json")
+    write_badge(findings, out_dir / "badge.svg")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main(sys.argv[1:]))

--- a/2026/Ontology-Term-Validation/ontology-terms@1.0.0.py
+++ b/2026/Ontology-Term-Validation/ontology-terms@1.0.0.py
@@ -7,10 +7,16 @@ PatchVersion: 0
 Publish: false
 Summary: Validates that ontology/CV annotations in ARC ISA tables are complete, well-formed, declared, and resolvable.
 Description: |
-  Checks ontology term annotations on Characteristic/Parameter/Factor/Component building
-  blocks across all study and assay tables. Offline: source/accession pairing,
-  well-formedness, source declaration, prefix consistency, free-text coverage. Online
-  (when the TIB Terminology Service is reachable): accession resolution and label match.
+  Checks the quality of ontology / controlled-vocabulary annotations on
+  Characteristic/Parameter/Factor/Component building blocks across all study and assay
+  tables. It verifies BOTH that used annotations are well-formed and structurally sound
+  (source/accession pairing, accession well-formedness) AND that, when ontology terms are
+  used, they resolve to real terms (online accession resolution and label match against
+  the TIB Terminology Service, with EBI OLS fallback). It does not require every value to
+  be annotated - free text is permitted, so coverage is only a warning. source_declared
+  and prefix_consistency are reported as non-critical warnings, since the Investigation
+  ONTOLOGY SOURCE REFERENCE section is not a settled convention and an ontology may host
+  terms whose id prefix differs from its source name.
 Author:
   - FullName: Mohamed Abouzid
     Email: m.abouzid@fz-juelich.de
@@ -149,27 +155,35 @@ def check_wellformed(occ):
 
 
 def check_source_declared(occ, declared):
+    # Non-critical (warning): the Investigation ONTOLOGY SOURCE REFERENCE section is not a
+    # reliably-populated convention across the ARC community (it is functionally an ISA
+    # artifact), so a missing declaration must not gate an ARC. See README friction note.
     if not occ.source:
-        return Finding("source_declared", "error", "skipped", "no source", occ.location)
+        return Finding("source_declared", "warning", "skipped", "no source", occ.location)
     declared_lower = {d.lower() for d in declared}
     if occ.source.lower() in declared_lower:
-        return _pass("source_declared", "error", occ)
-    return Finding("source_declared", "error", "failed",
+        return _pass("source_declared", "warning", occ)
+    return Finding("source_declared", "warning", "failed",
                    f"Term Source REF '{occ.source}' is not declared in the "
                    f"investigation ONTOLOGY SOURCE REFERENCE section.",
                    occ.location)
 
 
 def check_prefix_consistency(occ):
+    # Non-critical (warning): an ontology may legitimately host terms whose id prefix
+    # differs from its Term Source REF (e.g. the MS / psi-ms CV hosts PEFF: ids, so
+    # source=MS with accession=PEFF:0000002 is a real, valid term). A mismatch is a useful
+    # signal for genuine typos, but must not gate an ARC.
     if not (occ.source and occ.accession):
-        return Finding("prefix_consistency", "error", "skipped", "needs both", occ.location)
+        return Finding("prefix_consistency", "warning", "skipped", "needs both", occ.location)
     if _is_iri(occ.accession):
-        return Finding("prefix_consistency", "error", "skipped", "iri accession", occ.location)
+        return Finding("prefix_consistency", "warning", "skipped", "iri accession", occ.location)
     prefix = occ.accession.split(":", 1)[0]
     if prefix.lower() == occ.source.lower():
-        return _pass("prefix_consistency", "error", occ)
-    return Finding("prefix_consistency", "error", "failed",
-                   f"Accession prefix '{prefix}' does not match Term Source REF '{occ.source}'.",
+        return _pass("prefix_consistency", "warning", occ)
+    return Finding("prefix_consistency", "warning", "failed",
+                   f"Accession prefix '{prefix}' does not match Term Source REF '{occ.source}' "
+                   f"(may be legitimate for ontologies that host foreign-prefix terms).",
                    occ.location)
 
 


### PR DESCRIPTION
Adds 2026/Ontology_Term_Validation/: a Python ARC validation package that checks ontology/CV annotations (pairing, well-formedness, source declaration, prefix consistency, 
  coverage, plus live TIB/OLS term resolution). Includes the single-file package as payload. See the folder README for motivation, design constraints, and real-ARC results.