### PR TITLE
Update ARC-review process

### DIFF
--- a/ARC-Review-Process/README.md
+++ b/ARC-Review-Process/README.md
@@ -8,9 +8,15 @@ authors:
     orcid: orcid.org/0000-0002-4849-1537
     affiliation: 1
     role: Reviewer
+  - name: Dominik Brilhaus
+    orcid: https://orcid.org/0000-0001-9021-3197
+    affiliation: 2
+    role: Reviewer
 affiliations:
   - name: DataPLANT, eScience Department, University of Freiburg, Freiburg im Breisgau, Germany; Office for Research, University Development Department, RPTU University Kaiserslautern-Landau, Kaiserslautern, Germany
     index: 1
+  - name: Cluster of Excellence on Plant Sciences (CEPLAS), Faculty of Mathematics and Natural Science, Heinrich Heine University Düsseldorf, Düsseldorf, Germany
+    index: 2
 date: 25 June 2026
 ---
 
@@ -18,19 +24,19 @@ date: 25 June 2026
 
 This directory documents discussions and concepts related to the further development of the DataPLANT ARC publication and review workflow.
 
-The topics collected here summarize ideas, requirements and implementation suggestions that emerged from discussions between developers and reviewers. The primary focus is on improving the publication process, reviewer experience and the technical implementation of ARC publication within the DataPLANT environment.
+The topics collected here summarize ideas, requirements and implementation suggestions that emerged from discussions between developers and ARC reviewers. The primary focus is on improving the publication process, reviewer experience and tasks, reviewer-user-interaction, and the technical implementation of ARC publication within the DataPLANT environment.
 
 ## Scope
 
 Topics covered include:
 
 * ARC publication workflow
+  * Including publication embargos
 * Reviewer workflow
-* Community-based reviewing
-* Embargo publications
-* ARChigator and Invenio integration
-* Technical implementation concepts
-* Reviewer onboarding and communication
+  * Community-based reviewing
+  * Reviewer onboarding and communication
+* Technical implementation
+  * ARChigator and Invenio integration
 
 ## Background
 
@@ -49,12 +55,9 @@ The discussed workflow involves several DataPLANT components:
 | Invenio/ARChive  | Publication backend and DOI management | https://github.com/nfdi4plants/ARChive              |
 | DataHUB          | Repository and collaboration platform  | https://github.com/nfdi4plants/DataHUB              |
 | Storage Resolver | Resolves storage locations of data     | https://github.com/nfdi4plants/storage-resolver     |
+| arc-validate-package-registry (avpr) | Provides validation package for Invenio | https://github.com/nfdi4plants/arc-validate-package-registry |
 
 ---
-
-## Ideas and Concepts from Discussions
-
-The following ideas represent the current state of discussion and are not yet final decisions.
 
 ## Ideas and Concepts from the Discussions
 
@@ -63,7 +66,10 @@ The following ideas reflect the current state of the discussion and do not yet r
 ### Review Process
 
 * Introduction of a structured ARC review prior to publication
-* Separation of the submission, review, and publication phases
+* Separation into three phases:
+  1. ARC submission for revision initiated by users via the DataHUB interface
+  2. ARC-revision as bilateral exchange between ARC-reviewer and users via issues in the DataHUB interface
+  3. ARC publication and DOI-registration via Invenio triggered by the ARC-reviewer
 * Reviewer-driven creation of issues during the review process—ideally summarized in a milestone
 * Clear status transitions (e.g., submitted → under review → revision → accepted)
 
@@ -86,7 +92,7 @@ The following ideas reflect the current state of the discussion and do not yet r
 
 * Submission automatically triggers the review workflow (including assigning the reviewer account to the ARC to be reviewed)
 * Visual display of review status (e.g., badge: “Under Review”)
-* Ability to cancel submissions and cleanly revoke reviewers’ access
+* Ability to cancel submissions and cleanly revoke reviewers’ access via ARChigator dashboard
 * Resubmission triggers an updated review cycle
 * Selection of the community during the submission process
 


### PR DESCRIPTION
Some notes as time allowed. 
Major point IMO is just a small wording: I would suggest not to call the user's first step "submission". Submission for publication is done after revision or not? 
1. Validation (via DataHUB)
2. Request revision (via DataHUB badge + ARChigator button "request revision" vs. "cancel request") 
3. Revision (via DataHUB )
4. Submit for publication (via ? + Invenio) 
