### PR TITLE
Fix preview links in README for DataPLANT tool overview

### DIFF
--- a/DataPLANT-tool-overview/README.md
+++ b/DataPLANT-tool-overview/README.md
@@ -30,11 +30,8 @@ Two standalone HTML pages that can be opened in any browser without installation
 
 | File | Description | Preview |
 |---|---|---|
-| `DataPLANT_Tool_Overview.html` | Workflow-based onboarding overview organised into 5 steps (Create ARCs → Annotate → Collaborate → Publish → Learn). Filterable by category, searchable, with "When do I use this?" guidance per tool. | [▶ Open preview](https://htmlpreview.github.io/?https://github.com/SabrinaZander/ARC-Symposium/blob/DataPLANT-tool-overview/DataPLANT-tool-overview/DataPLANT_Tool_Overview.html) |
-| `DataPLANT_Interactive_Map.html` | Draggable node map showing all tools and their dependencies. Nodes can be rearranged freely; arrows update live. Click any node for details and contact persons. | [▶ Open preview](https://htmlpreview.github.io/?https://github.com/SabrinaZander/ARC-Symposium/blob/DataPLANT-tool-overview/DataPLANT-tool-overview/DataPLANT_Interactive_Map.html) |
-
-> **Note:** Preview links point to the current branch. Once this PR is merged into the main DataPLANT repository, update the links above to reflect the new path, e.g.:
-> `https://htmlpreview.github.io/?https://github.com/nfdi4plants/ARC-Symposium/blob/main/DataPLANT-tool-overview/DataPLANT_Tool_Overview.html`
+| `DataPLANT_Tool_Overview.html` | Workflow-based onboarding overview organised into 5 steps (Create ARCs → Annotate → Collaborate → Publish → Learn). Filterable by category, searchable, with "When do I use this?" guidance per tool. | [▶ Open preview](https://htmlpreview.github.io/?https://github.com/nfdi4plants/ARC-Symposium/blob/main/DataPLANT-tool-overview/DataPLANT_Tool_Overview.html) |
+| `DataPLANT_Interactive_Map.html` | Draggable node map showing all tools and their dependencies. Nodes can be rearranged freely; arrows update live. Click any node for details and contact persons. | [▶ Open preview](https://htmlpreview.github.io/?https://github.com/nfdi4plants/ARC-Symposium/blob/main/DataPLANT-tool-overview/DataPLANT_Interactive_Map.html) |
 
 Both files are **fully self-contained** — they work offline and require no server or framework.
 


### PR DESCRIPTION
Updated preview links in README to point to the main repository.